### PR TITLE
Check for "peer == nil" in SetData

### DIFF
--- a/mesh/peer.go
+++ b/mesh/peer.go
@@ -265,6 +265,9 @@ func (peer *Peer) InactiveFor() float64 {
 }
 
 func (peer *Peer) SetData(adv map[string]interface{}) {
+	if peer == nil {
+		return
+	}
 	peer.Lock()
 	defer peer.Unlock()
 


### PR DESCRIPTION
When "-advertising=false", mesh does not get set up, but further errors occur when SetData gets called. This check probably belongs in all of the functions. But with this in, SetData can get called and it just returns if advertising is off and peer wasn't set up.

This got pwngrid running on my bananapi m4zero with a "bad" realtek chip that won't do the special beacon mode (or whatever)