### PR TITLE
net/http: TLS handshake timeout on original ZeroW.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 	"time"
+        "net"
 
 	"github.com/evilsocket/islazy/log"
 	"github.com/jayofelony/pwngrid/crypto"
@@ -19,6 +20,7 @@ import (
 
 var (
 	ClientTimeout   = 60
+	ClientKeepalive = 30
 	ClientTokenFile = "/tmp/pwngrid-api-enrollment.json"
 	Endpoint        = ""
 )
@@ -38,8 +40,19 @@ type Client struct {
 }
 
 func NewClient(keys *crypto.KeyPair, endpoint string) *Client {
+	t := &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   time.Duration(ClientTimeout) * time.Second,
+			KeepAlive: time.Duration(ClientKeepalive) * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: time.Duration(ClientTimeout) * time.Second,
+		ResponseHeaderTimeout: time.Duration(ClientTimeout) * time.Second,
+		ExpectContinueTimeout: 4 * time.Second,
+	}
+
 	cli := &Client{
 		cli: &http.Client{
+			Transport: t,
 			Timeout: time.Duration(ClientTimeout) * time.Second,
 		},
 		keys: keys,

--- a/version/ver.go
+++ b/version/ver.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version = "1.11.2"
+	Version = "1.11.3"
 )

--- a/version/ver.go
+++ b/version/ver.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version = "1.11.1"
+	Version = "1.11.2"
 )


### PR DESCRIPTION
The original ZeroW is too underpowered to perform a full handshake under load now that everyone is using modern TLS. This results in lots of **net/http: TLS handshake timeout** errors which prevent enrolment and access to inbox on occasion.

This small fix resolves that and makes slow connections a little more reliable.