### PR TITLE
makefile: install systemd service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install:
 	@mkdir -p /etc/systemd/system/
 	@mkdir -p /etc/pwngrid/
 	@cp env.example /etc/pwngrid/pwngrid.conf
+	@cp pwngrid-peer.service /etc/systemd/system/
 	@systemctl daemon-reload
 
 clean:


### PR DESCRIPTION
we need to install `pwngrid-peer.service` when use `make install` so we don't need to copy systemd unit file manually.